### PR TITLE
Add script for Fedora 28 installation

### DIFF
--- a/scripts/install-fedora-28.sh
+++ b/scripts/install-fedora-28.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Privilege verification
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+set -e 
+
+dnf clean all
+dnf install -y openssl-devel libtool gcc automake
+
+cd ../tpm
+make -f makefile-tpm
+
+install -c tpm_server /usr/local/bin/tpm_server
+
+cd ../libtpm
+./comp-sockets.sh
+make install
+
+cd ../scripts
+install -c tpm_serverd /usr/local/bin/tpm_serverd
+install -c init_tpm_server /usr/local/bin/init_tpm_server
+
+init_tpm_server
+
+tpm_serverd
+


### PR DESCRIPTION
Our Keylime project is using TPM4720 on Fedora, so I added a tpm emulator installation script based on on install-centos.sh. Tested and verified the script is working on Fedora 28 VM. Furhter test onFedora 29 VM and Fedora 29 w/ TPM1.2 chip will be done in the future. Thanks.